### PR TITLE
remove s from https

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,3 +1,3 @@
 # animator.js
 
-A JavaScript/CSS animation library. Read about it here: https://blog.berniesumption.com/software/animator/
+A JavaScript/CSS animation library. Read about it here: http://blog.berniesumption.com/software/animator/


### PR DESCRIPTION
link doesnt work over ssl

Note: Found this via a project that uses it. I was surprised when I saw this was released 4 years ago, must have been ahead of others at that time. neways i figured I would update for you if you dont plan to implement ssl on your site
